### PR TITLE
Use version in snapshot metadata instead of hardcoded value

### DIFF
--- a/torchsnapshot/__init__.py
+++ b/torchsnapshot/__init__.py
@@ -11,11 +11,10 @@ from .rng_state import RNGState
 from .snapshot import Snapshot
 from .state_dict import StateDict
 from .stateful import Stateful
-
-
-__version__ = "0.0.2"
+from .version import __version__
 
 __all__ = [
+    "__version__",
     "Snapshot",
     "Stateful",
     "StateDict",

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -31,6 +31,7 @@ from .pg_wrapper import PGWrapper
 from .rng_state import RNGState
 from .stateful import AppState, Stateful
 from .storage_plugin import url_to_storage_plugin
+from .version import __version__ as torchsnapshot_version
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -429,7 +430,7 @@ path "{logical_path}" which was not available to rank {rank}.
     ) -> None:
         # TODO: use semantic versioning for backward compatibility
         snapshot_metadata = SnapshotMetadata(
-            version="0.0.1", world_size=world_size, manifest=manifest
+            version=torchsnapshot_version, world_size=world_size, manifest=manifest
         )
         io_req = IOReq(
             path=SNAPSHOT_METADATA_FNAME,

--- a/torchsnapshot/version.py
+++ b/torchsnapshot/version.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Follows PEP-0440 version scheme guidelines
+# https://www.python.org/dev/peps/pep-0440/#version-scheme
+#
+# Examples:
+# 0.1.0.devN # Developmental release
+# 0.1.0aN  # Alpha release
+# 0.1.0bN  # Beta release
+# 0.1.0rcN  # Release Candidate
+# 0.1.0  # Final release
+__version__: str = "0.0.2"


### PR DESCRIPTION
Summary: Version is populated in `__init__.py` and we should use it here

Differential Revision: D37151856

