### PR TITLE
Add a pre-commit config and fix formatting issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,19 @@
+[flake8]
+# Suggested config from pytorch that we can adopt
+select = B,C,E,F,P,T4,W,B9
+max-line-length = 120
+# C408 ignored because we like the dict keyword argument syntax
+# E501 is not flexible enough, we're using B950 instead
+ignore =
+    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
+    # shebang has extra meaning in fbcode lints, so I think it's not worth trying
+    # to line this up with executable bit
+    EXE001,
+optional-ascii-coding = True
+exclude =
+    ./.git,
+    ./docs
+    ./build
+    ./scripts,
+    ./venv,
+    *.pyi

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -36,4 +36,4 @@ jobs:
           conda activate test
           pytest --cov=. --cov-report xml tests -vv
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v2 
+        uses: codecov/codecov-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+default_language_version:
+    python: python3
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-ast
+    -   id: check-merge-conflict
+    -   id: no-commit-to-branch
+    -   id: check-added-large-files
+        args: ['--maxkb=500']
+    -   id: end-of-file-fixer
+
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.7
+    hooks:
+    -   id: insert-license
+        files: \.py$
+        args:
+        - --license-filepath
+        - docs/license_header.txt
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+        args:
+        - --config=.flake8
+
+-   repo: https://github.com/omnilib/ufmt
+    rev: v1.3.0
+    hooks:
+    - id: ufmt
+      additional_dependencies:
+        - black == 22.3.0
+        - usort == 1.0.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 numpy
+pre-commit
 pytest
 pytest-cov

--- a/docs/license_header.txt
+++ b/docs/license_header.txt
@@ -1,0 +1,5 @@
+Copyright (c) Meta Platforms, Inc. and affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.

--- a/torchsnapshot/storage_plugins/__init__.py
+++ b/torchsnapshot/storage_plugins/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchsnapshot/storage_plugins/fs.py
+++ b/torchsnapshot/storage_plugins/fs.py
@@ -12,6 +12,7 @@ from typing import Set
 
 import aiofiles
 import aiofiles.os
+
 from torchsnapshot.io_types import IOReq, StoragePlugin
 
 

--- a/torchsnapshot/torch_dist_checkpoint/__init__.py
+++ b/torchsnapshot/torch_dist_checkpoint/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchsnapshot/torch_dist_checkpoint/resharding.py
+++ b/torchsnapshot/torch_dist_checkpoint/resharding.py
@@ -12,6 +12,7 @@ from torch.distributed._shard.sharding_spec import ShardMetadata
 from torch.distributed._shard.sharding_spec._internals import (
     _check_shard_metadata_pair_overlap,
 )
+
 from torchsnapshot.torch_dist_checkpoint.metadata import (
     ExtendedTensorMetadata,
     StorageMetadata,


### PR DESCRIPTION
As described in the title, we would like to add a `pre-commit` config for the repo. The other changes are needed to make `pre-commit run --all-files` pass.