### PR TITLE
Smaller shards for sharded tensors

### DIFF
--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -35,7 +35,7 @@ from .torch_dist_checkpoint.resharding import prepare_sharded_tensor_read
 
 
 class ShardedTensorIOPreparer:
-    DEFAULT_MAX_SHARD_SIZE_BYTES: int = 1 * 1024 * 1024 * 1024
+    DEFAULT_MAX_SHARD_SIZE_BYTES: int = 512 * 1024 * 1024
 
     @staticmethod
     def subdivide_shard(


### PR DESCRIPTION
google cloud storage seems to prefer files closer to 100 MB than 1 GB and has less errors like https://github.com/googleapis/google-cloud-ruby/issues/2516

`BrokenPipeError` is not caught by `google-cloud-storage`'s native retry capabilities.