### PR TITLE
GCSPlugin: use RawChunkedDownload and set chunk size to 100MB

### DIFF
--- a/torchsnapshot/storage_plugins/gcs.py
+++ b/torchsnapshot/storage_plugins/gcs.py
@@ -51,9 +51,10 @@ class GCSStoragePlugin(StoragePlugin):
 
     async def read(self, io_req: IOReq) -> None:
         loop = asyncio.get_running_loop()
-        key = os.path.join("gs://", self.bucket_name, self.root, io_req.path)
+        key = os.path.join(self.root, io_req.path)
+        blob = self.bucket.blob(key, chunk_size=100 * 1024 * 1024)
         await loop.run_in_executor(
-            self.executor, partial(self.client.download_blob_to_file, key, io_req.buf)
+            self.executor, partial(blob.download_to_file, io_req.buf, raw_download=True)
         )
         io_req.buf.seek(0)
 


### PR DESCRIPTION
Client.download_blob_to_file() seems to always use a chunk size of
8192. While Blob.download_to_file() is deprecated, it seems to be the
only way to dispatch to RawChunkedDownload.