### PR TITLE
StateDict.state_dict() should return a dict

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -22,6 +22,7 @@ class SnapshotTest(unittest.TestCase):
         foo = torchsnapshot.StateDict(a=torch.rand(40, 40), b=torch.rand(40, 40), c=42)
         bar = torchsnapshot.StateDict(a=torch.rand(40, 40), b=torch.rand(40, 40), c=43)
         self.assertFalse(check_state_dict_eq(foo.state_dict(), bar.state_dict()))
+        self.assertTrue(type(foo.state_dict()) == dict)
 
         with tempfile.TemporaryDirectory() as path:
             snapshot = torchsnapshot.Snapshot.take(path, {"foo": foo})

--- a/torchsnapshot/state_dict.py
+++ b/torchsnapshot/state_dict.py
@@ -5,12 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import UserDict
 from typing import Any, Dict
 
 
-# pyre-fixme[24]: Generic type `dict` expects 2 type parameters, use `typing.Dict`
-#  to avoid runtime subscripting errors.
-class StateDict(dict):
+# pyre-fixme[24]: Python <3.9 doesn't support typing on UserDict
+class StateDict(UserDict):
     """
     A dict that implements the Stateful protocol. It is handy for capturing
     stateful objects that do not already implement the Stateful protocol or
@@ -35,7 +35,7 @@ class StateDict(dict):
     """
 
     def state_dict(self) -> Dict[str, Any]:
-        return self
+        return self.data
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        self.update(state_dict)
+        self.data.update(state_dict)


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/facebookresearch/torchsnapshot/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

Summary:
<!-- Change Summary -->

StateDict was being flattened because it wasn't an OrderedDict or a regular dict.

Test plan:

unit test

manual test:
```
from torchsnapshot import Snapshot, StateDict
d = StateDict()
d["a"] = {"c": torch.Tensor(1), "d": torch.Tensor(2)}
app_state = {"qwert": d}
Snapshot.take(path="lol", app_state=app_state)
```

expect `0/qwert/` to have two files, c and d.


<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
