### PR TITLE
Parallelize buffer consumption during load

### DIFF
--- a/torchsnapshot/io_types.py
+++ b/torchsnapshot/io_types.py
@@ -33,7 +33,9 @@ class WriteReq:
 
 class BufferConsumer:
     @abc.abstractmethod
-    async def consume_buffer(self, buf: BufferType) -> None:
+    async def consume_buffer(
+        self, buf: BufferType, executor: Optional[Executor] = None
+    ) -> None:
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
Summary:
- Parallelize buffer consumption (e.g. deserialization, HtoD copy) during load
- Better utilize CPU and PCIe bandwidth
- Don't block the main thread so that read requests can be dispatched more quickly

Test plan:
Existing unit tests