### PR TITLE
Fix an issue with absolute paths in storage plugin tests

### DIFF
--- a/tests/test_fs_storage_plugin.py
+++ b/tests/test_fs_storage_plugin.py
@@ -28,18 +28,18 @@ class FSStoragePluginTest(unittest.TestCase):
 
             tensor = torch.rand((_TENSOR_SZ,))
             tensor_path = os.path.join(path, "tensor")
-            write_req = torchsnapshot.io_types.IOReq(path=tensor_path)
+            write_req = torchsnapshot.io_types.IOReq(path="tensor")
             torch.save(tensor, write_req.buf)
 
             loop = asyncio.new_event_loop()
             loop.run_until_complete(plugin.write(io_req=write_req))
             self.assertTrue(os.path.exists(tensor_path))
 
-            read_req = torchsnapshot.io_types.IOReq(path=tensor_path)
+            read_req = torchsnapshot.io_types.IOReq(path="tensor")
             loop.run_until_complete(plugin.read(io_req=read_req))
             loaded = torch.load(read_req.buf)
             self.assertTrue(torch.allclose(tensor, loaded))
 
-            loop.run_until_complete(plugin.delete(path=tensor_path))
+            loop.run_until_complete(plugin.delete(path="tensor"))
             self.assertFalse(os.path.exists(tensor_path))
             plugin.close()

--- a/tests/test_gcs_storage_plugin.py
+++ b/tests/test_gcs_storage_plugin.py
@@ -46,17 +46,16 @@ class GCSStoragePluginTest(unittest.TestCase):
         plugin = GCSStoragePlugin(root=path)
 
         tensor = torch.rand((_TENSOR_SZ,))
-        path = os.path.join(path, "tensor")
-        write_req = torchsnapshot.io_types.IOReq(path=path)
+        write_req = torchsnapshot.io_types.IOReq(path="tensor")
         torch.save(tensor, write_req.buf)
 
         loop = asyncio.new_event_loop()
         loop.run_until_complete(plugin.write(io_req=write_req))
 
-        read_req = torchsnapshot.io_types.IOReq(path=path)
+        read_req = torchsnapshot.io_types.IOReq(path="tensor")
         loop.run_until_complete(plugin.read(io_req=read_req))
         loaded = torch.load(read_req.buf)
         self.assertTrue(torch.allclose(tensor, loaded))
 
-        loop.run_until_complete(plugin.delete(path=path))
+        loop.run_until_complete(plugin.delete(path="tensor"))
         plugin.close()

--- a/tests/test_s3_storage_plugin.py
+++ b/tests/test_s3_storage_plugin.py
@@ -44,17 +44,16 @@ class S3StoragePluginTest(unittest.TestCase):
         plugin = S3StoragePlugin(root=path)
 
         tensor = torch.rand((_TENSOR_SZ,))
-        path = os.path.join(path, "tensor")
-        write_req = torchsnapshot.io_types.IOReq(path=path)
+        write_req = torchsnapshot.io_types.IOReq(path="tensor")
         torch.save(tensor, write_req.buf)
 
         loop = asyncio.new_event_loop()
         loop.run_until_complete(plugin.write(io_req=write_req))
 
-        read_req = torchsnapshot.io_types.IOReq(path=path)
+        read_req = torchsnapshot.io_types.IOReq(path="tensor")
         loop.run_until_complete(plugin.read(io_req=read_req))
         loaded = torch.load(read_req.buf)
         self.assertTrue(torch.allclose(tensor, loaded))
 
-        loop.run_until_complete(plugin.delete(path=path))
+        loop.run_until_complete(plugin.delete(path="tensor"))
         plugin.close()

--- a/torchsnapshot/storage_plugins/fs.py
+++ b/torchsnapshot/storage_plugins/fs.py
@@ -39,6 +39,7 @@ class FSStoragePlugin(StoragePlugin):
             io_req.buf = io.BytesIO(await f.read())
 
     async def delete(self, path: str) -> None:
+        path = os.path.join(self.root, path)
         await aiofiles.os.remove(path)
 
     async def close(self) -> None:


### PR DESCRIPTION
Summary:
The storage plugin tests currently result in unnecessary nested directory structures in the test buckets (see the attached screenshot). Since we already prepend the root path to the object path before reading, writing, or deleting the object from storage (e.g. see [this line](https://www.internalfb.com/code/fbsource/%5B243580256d2a%5D/fbcode/torchsnapshot/storage_plugins/s3.py?lines=36)), there is no need to do it before calling the storage API.

Interesting, this problem isn't observed locally as joining with an absolute path ignores everything that comes before it (e.g. `os.path.join('x/y/z', '/a/b/c/')` returns `/a/b/c/`; see [this documentation](https://docs.python.org/3/library/os.path.html#os.path.join)).
{F748317683}

Differential Revision: D37510959

