### PR TITLE
support serialization through buffer protocol

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torchsnapshot.serialization import (
+    ALL_SUPPORTED_DTYPES,
+    BUFFER_PROTOCOL_SUPPORTED_DTYPES,
+    dtype_to_string,
+    string_to_dtype,
+    tensor_as_memoryview,
+    tensor_from_memoryview,
+)
+
+
+class SerializationTest(unittest.TestCase):
+    TENSOR_DIM = (1000, 1000)
+
+    def _test_buffer_protocol_helper(self, dtype: torch.dtype) -> None:
+        if dtype.is_floating_point:
+            foo = torch.randn(self.TENSOR_DIM, dtype=dtype)
+        elif dtype == torch.bool:
+            foo = torch.randint(1, self.TENSOR_DIM, dtype=dtype)
+        else:
+            foo = torch.randint(torch.iinfo(dtype).max, self.TENSOR_DIM, dtype=dtype)
+
+        serialized = tensor_as_memoryview(foo).tobytes()
+        dtype_str = dtype_to_string(foo.dtype)
+        shape = list(foo.shape)
+
+        bar = tensor_from_memoryview(
+            memoryview(serialized),
+            dtype=string_to_dtype(dtype_str),
+            shape=shape,
+        )
+        self.assertTrue(torch.allclose(foo, bar))
+
+    def test_buffer_protocol(self) -> None:
+        for dtype in BUFFER_PROTOCOL_SUPPORTED_DTYPES:
+            with self.subTest(dtype=dtype):
+                self._test_buffer_protocol_helper(dtype)
+
+    def test_string_dtype_conversion(self) -> None:
+        for dtype in ALL_SUPPORTED_DTYPES:
+            with self.subTest(dtype=dtype):
+                dtype_str = dtype_to_string(dtype)
+                restored = string_to_dtype(dtype_str)
+                self.assertEqual(restored, dtype)

--- a/torchsnapshot/io_types.py
+++ b/torchsnapshot/io_types.py
@@ -10,9 +10,10 @@ import asyncio
 import io
 from concurrent.futures import Executor
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Union
 
-BufferType = bytes  # TODO: add memoryview
+
+BufferType = Union[bytes, memoryview]
 
 
 class BufferStager:
@@ -34,7 +35,7 @@ class WriteReq:
 class BufferConsumer:
     @abc.abstractmethod
     async def consume_buffer(
-        self, buf: BufferType, executor: Optional[Executor] = None
+        self, buf: bytes, executor: Optional[Executor] = None
     ) -> None:
         pass
 

--- a/torchsnapshot/serialization.py
+++ b/torchsnapshot/serialization.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import logging
+from enum import Enum
+from typing import Dict, List
+
+import torch
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# https://pytorch.org/docs/stable/tensors.html#data-types
+ALL_SUPPORTED_DTYPES: List[torch.dtype] = [
+    torch.float64,
+    torch.float32,
+    torch.float16,
+    torch.bfloat16,
+    torch.complex128,
+    torch.complex64,
+    torch.int64,
+    torch.int32,
+    torch.int16,
+    torch.int8,
+    torch.uint8,
+    torch.bool,
+    torch.qint32,
+    torch.qint8,
+    torch.quint8,
+]
+
+# The approach is dumb. But we want to be 100% certain we can recognize the
+# dtype strings we persist.
+_DTYPE_TO_STRING: Dict[torch.dtype, str] = {
+    torch.float64: "torch.float64",
+    torch.float32: "torch.float32",
+    torch.float16: "torch.float16",
+    torch.bfloat16: "torch.bfloat16",
+    torch.complex128: "torch.complex128",
+    torch.complex64: "torch.complex64",
+    torch.int64: "torch.int64",
+    torch.int32: "torch.int32",
+    torch.int16: "torch.int16",
+    torch.int8: "torch.int8",
+    torch.uint8: "torch.uint8",
+    torch.bool: "torch.bool",
+    torch.qint32: "torch.qint32",
+    torch.qint8: "torch.qint8",
+    torch.quint8: "torch.quint8",
+}
+
+# This could be figured out by creating an empty tensor with the dtype and
+# checking its .element_size(). However, the approach may not work for
+# quantized dtypes if the appropriate backend is not available. Since special
+# casing is inevitable, we might as well enumerate all dtypes.
+_DTYPE_TO_ELEMENT_SIZE: Dict[torch.dtype, int] = {
+    torch.float64: 8,
+    torch.float32: 4,
+    torch.float16: 2,
+    torch.bfloat16: 2,
+    torch.complex128: 16,
+    torch.complex64: 8,
+    torch.int64: 8,
+    torch.int32: 4,
+    torch.int16: 2,
+    torch.int8: 1,
+    torch.uint8: 1,
+    torch.bool: 1,
+    torch.qint32: 4,
+    torch.qint8: 1,
+    torch.quint8: 1,
+}
+
+
+# The approach is dumb. But we want to be 100% certain we can recognize the
+# dtype strings we persist.
+_STRING_TO_DTYPE: Dict[str, torch.dtype] = {
+    "torch.float64": torch.float64,
+    "torch.float32": torch.float32,
+    "torch.float16": torch.float16,
+    "torch.bfloat16": torch.bfloat16,
+    "torch.complex128": torch.complex128,
+    "torch.complex64": torch.complex64,
+    "torch.int64": torch.int64,
+    "torch.int32": torch.int32,
+    "torch.int16": torch.int16,
+    "torch.int8": torch.int8,
+    "torch.uint8": torch.uint8,
+    "torch.bool": torch.bool,
+    "torch.qint32": torch.qint32,
+    "torch.qint8": torch.qint8,
+    "torch.quint8": torch.quint8,
+}
+
+
+def dtype_to_string(dtype: torch.dtype) -> str:
+    """
+    Converty a class::`torch.dtype` to class::`str`.
+    """
+    if dtype in _DTYPE_TO_STRING:
+        return _DTYPE_TO_STRING[dtype]
+    else:
+        raise ValueError(f"Unsupported dtype {dtype}.")
+
+
+def dtype_to_element_size(dtype: torch.dtype) -> int:
+    if dtype in _DTYPE_TO_ELEMENT_SIZE:
+        return _DTYPE_TO_ELEMENT_SIZE[dtype]
+    else:
+        raise ValueError(f"Unsupported dtype {dtype}.")
+
+
+def string_to_dtype(s: str) -> torch.dtype:
+    """
+    Converty a class::`torch.dtype` to class::`str`.
+    """
+    if s in _STRING_TO_DTYPE:
+        return _STRING_TO_DTYPE[s]
+    else:
+        raise ValueError(f"Unsupported dtype {s}.")
+
+
+class Serializer(Enum):
+    TORCH_SAVE = "torch_save"
+    BUFFER_PROTOCOL = "buffer_protocol"
+
+
+BUFFER_PROTOCOL_SUPPORTED_DTYPES: List[torch.dtype] = [
+    torch.float64,
+    torch.float32,
+    torch.float16,
+    torch.bfloat16,
+    torch.int64,
+    torch.int32,
+    torch.int16,
+    torch.int8,
+    torch.uint8,
+    torch.bool,
+]
+
+
+def tensor_as_memoryview(tensor: torch.Tensor) -> memoryview:
+    """
+    Obtain the class::`memoryview` of a class::`torch.Tensor`.
+
+    It is the caller's responsibility to ensure that the input is a CPU tensor
+    and its dtype is defined in `BUFFER_PROTOCOL_SUPPORTED_DTYPES`. The
+    function will raise an exception if the requirements are not met.
+
+    Args:
+        tensor: The `bfloat16` tensor from which to obtain memoryview.
+
+    Returns:
+        The class::`memoryview` of the input tensor.
+    """
+    if tensor.dtype not in BUFFER_PROTOCOL_SUPPORTED_DTYPES:
+        raise ValueError(
+            f"tensor_as_memoryview() doesn't support the dtype {tensor.dtype}."
+        )
+    if tensor.device != torch.device("cpu"):
+        raise ValueError("tensor_as_memoryview() only accepts CPU tensors.")
+    if not tensor.is_contiguous():
+        # This is only needed if the caller didn't need to copied the tensor
+        # from device to CPU. This is still more efficient than torch.save().
+        tensor = tensor.contiguous()
+    if tensor.dtype == torch.bfloat16:
+        return _bfloat16_tensor_to_memoryview(tensor)
+    return memoryview(tensor.numpy())
+
+
+def _bfloat16_tensor_to_memoryview(tensor: torch.Tensor) -> memoryview:
+    """
+    A specialization of func::`tensor_as_memoryview` for `bfloa16`.
+
+    Currently the memoryview of a tensor can only be obtained via its numpy
+    array representation. However, numpy doesn't support `bfloat16`, so
+    `bfloat16` tensor's can't be converted to a numpy array.
+
+    Since we only need the memoryview to avoid data copies, we can workaround
+    this limitation by reinterpret casting the `bfloat16` tensor to a `float16`
+    tensor.
+
+    Args:
+        tensor: The `bfloat16` tensor from which to obtain memoryview.
+
+    Returns:
+        The class::`memoryview` of the input tensor.
+    """
+    if tensor.dtype != torch.bfloat16:
+        raise ValueError(
+            "The input tensor must have be of type torch.bfloat16 "
+            f"(got {tensor.dtype})."
+        )
+    untyped_storage = tensor.storage()._untyped()
+    tensor = torch.empty(tensor.size(), dtype=torch.float16)
+    tensor.set_(untyped_storage)
+    return memoryview(tensor.numpy())
+
+
+def tensor_from_memoryview(
+    mv: memoryview, dtype: torch.dtype, shape: List[int]
+) -> torch.Tensor:
+    return torch.reshape(torch.frombuffer(mv, dtype=dtype), shape)
+
+
+def torch_save_as_bytes(tensor: torch.Tensor) -> bytes:
+    buf = io.BytesIO()
+    torch.save(tensor, buf)
+    return buf.getvalue()
+
+
+def torch_load_from_bytes(buf: bytes) -> torch.Tensor:
+    return torch.load(io.BytesIO(buf))

--- a/torchsnapshot/test_utils.py
+++ b/torchsnapshot/test_utils.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-ignore-all-errors[2]: allow `Any` in type annotations
+
 import unittest
 import uuid
 from contextlib import contextmanager
@@ -17,7 +19,6 @@ import torch.distributed.launcher as pet
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 
 
-# pyre-ignore[2]: Parameter annotation cannot contain `Any`.
 def _tensor_eq(lhs: Union[torch.Tensor, ShardedTensor], rhs: Any) -> bool:
     if type(lhs) != type(rhs):
         return False
@@ -51,9 +52,7 @@ def _patch_tensor_eq() -> Generator[None, None, None]:
 
 def assert_state_dict_eq(
     tc: unittest.TestCase,
-    # pyre-ignore[2]: Parameter annotation cannot contain `Any`.
     lhs: Dict[Any, Any],
-    # pyre-ignore[2]: Parameter annotation cannot contain `Any`.
     rhs: Dict[Any, Any],
 ) -> None:
     """
@@ -68,7 +67,6 @@ def assert_state_dict_eq(
         tc.assertDictEqual(lhs, rhs)
 
 
-# pyre-ignore[2]: Parameter annotation cannot contain `Any`.
 def check_state_dict_eq(lhs: Dict[Any, Any], rhs: Dict[Any, Any]) -> bool:
     """
     dict.__eq__ except that it knows how to handle tensors.


### PR DESCRIPTION
Summary:
This removes all memory copy incurred by `torch.save()`. Currently, the
following dtypes are supported:

- torch.float64,
- torch.float32,
- torch.float16,
- torch.bfloat16,
- torch.int64,
- torch.int32,
- torch.int16,
- torch.int8,
- torch.uint8,
- torch.bool,

Unsupported dtypes will fallback to `torch.save()`.

Differential Revision: D37117206

